### PR TITLE
FIX for #49: Ensuring unassociated <video> elements are not reloaded unnecessarily.

### DIFF
--- a/dist/jquery.lazyloadxt.extra.js
+++ b/dist/jquery.lazyloadxt.extra.js
@@ -137,6 +137,9 @@
      * @param {jQuery} $el
      */
     function triggerEvent(event, $el) {
+        // Don't bother triggering events on elements that we're not keeping track of.
+        if ($.inArray($el, elements) === -1) return;
+
         var handler = options['on' + event];
         if (handler) {
             if ($isFunction(handler)) {

--- a/dist/jquery.lazyloadxt.js
+++ b/dist/jquery.lazyloadxt.js
@@ -137,6 +137,9 @@
      * @param {jQuery} $el
      */
     function triggerEvent(event, $el) {
+        // Don't bother triggering events on elements that we're not keeping track of.
+        if ($.inArray($el, elements) === -1) return;
+
         var handler = options['on' + event];
         if (handler) {
             if ($isFunction(handler)) {

--- a/src/jquery.lazyloadxt.js
+++ b/src/jquery.lazyloadxt.js
@@ -133,6 +133,9 @@
      * @param {jQuery} $el
      */
     function triggerEvent(event, $el) {
+        // Don't bother triggering events on elements that we're not keeping track of.
+        if ($.inArray($el, elements) === -1) return;
+
         var handler = options['on' + event];
         if (handler) {
             if ($isFunction(handler)) {


### PR DESCRIPTION
Helps with ensuring unassociated <video> elements are not reloaded even though they may already be visible and/or are not loaded lazily.