### PR TITLE
Add a check in background plugin to prevent undefined background styles injected

### DIFF
--- a/dist/jquery.lazyloadxt.bg.js
+++ b/dist/jquery.lazyloadxt.bg.js
@@ -11,9 +11,11 @@
 
     $(document).on('lazyshow', function (e) {
         var $this = $(e.target);
-        $this
-            .css('background-image', "url('" + $this.attr(bgAttr) + "')")
-            .removeAttr(bgAttr);
+        if( typeof( $this.attr(bgAttr) ) != 'undefined' ) {
+            $this
+                .css('background-image', "url('" + $this.attr(bgAttr) + "')")
+                .removeAttr(bgAttr);
+        }        
     });
 
 })(window.jQuery || window.Zepto || window.$);


### PR DESCRIPTION
If background plugin is used at the same time as DOM elements that is set to lazy load, the background plugin incorrectly also injects a background-image style to each element. This causes a lot of undefined image loading

```style="background-image: url(http://magento.zabadaclean.biz/undefined);"```

This fix ads a check to determine that an element has a valid defined bgAttr set.