### PR TITLE
Remove dataLazied from the removed elements

### DIFF
--- a/src/jquery.lazyloadxt.js
+++ b/src/jquery.lazyloadxt.js
@@ -227,6 +227,7 @@
             }
 
             if (removeNode) {
+                $data(el, dataLazied, 0);
                 elements.splice(i--, 1);
                 length--;
             }


### PR DESCRIPTION
This is so that they're not detected as duplicates if they're reattached to the DOM in the future.