### PR TITLE
Fix out-of-date link anchors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,12 @@ Addons:
 <table>
   <tbody>
     <tr>
-      <td><a href="#script-based-tagging-of-lazy-loaded-elements">script-based tagging of lazy loaded elements</a></td>
+      <td><a href="#script-based-tagging">script-based tagging of lazy loaded elements</a></td>
       <td><a href="https://raw.github.com/ressio/lazy-load-xt/master/dist/jquery.lazyloadxt.script.js">[jquery.lazyloadxt.script.js</a></td>
       <td><a href="https://raw.github.com/ressio/lazy-load-xt/master/dist/jquery.lazyloadxt.script.min.js">jquery.lazyloadxt.script.min.js</a></td>
     </tr>
     <tr>
-      <td><a href="#responsive-images-and-srcset">Responsive images and srcset</a></td>
+      <td><a href="#responsive-images">Responsive images and srcset</a></td>
       <td><a href="https://raw.github.com/ressio/lazy-load-xt/master/dist/jquery.lazyloadxt.srcset.js">jquery.lazyloadxt.srcset.js</a></td>
       <td><a href="https://raw.github.com/ressio/lazy-load-xt/master/dist/jquery.lazyloadxt.srcset.min.js">jquery.lazyloadxt.srcset.min.js</a></td>
     </tr>
@@ -108,7 +108,7 @@ Addons:
       <td><a href="https://raw.github.com/ressio/lazy-load-xt/master/dist/jquery.lazyloadxt.bg.min.js">jquery.lazyloadxt.bg.min.js</a></td>
     </tr>
     <tr>
-      <td><a href="#deferred-load">Deferred load</a></td>
+      <td><a href="#deferred-autoload">Deferred load</a></td>
       <td><a href="https://raw.github.com/ressio/lazy-load-xt/master/dist/jquery.lazyloadxt.autoload.js">jquery.lazyloadxt.autoload.js</a></td>
       <td><a href="https://raw.github.com/ressio/lazy-load-xt/master/dist/jquery.lazyloadxt.autoload.min.js">jquery.lazyloadxt.autoload.min.js</a></td>
      </tr>


### PR DESCRIPTION
Just changed the link anchors to point to the correct parts of the README.md