### PR TITLE
Trigger load event for videos (#27 #75 #86)

### DIFF
--- a/src/jquery.lazyloadxt.js
+++ b/src/jquery.lazyloadxt.js
@@ -8,7 +8,7 @@
     // options
     var lazyLoadXT = 'lazyLoadXT',
         dataLazied = 'lazied',
-        load_error = 'load error',
+        load_error = 'load loadeddata error',
         classLazyHidden = 'lazy-hidden',
         docElement = document.documentElement || document.body,
     //  force load all images in Opera Mini and some mobile browsers without scroll event or getBoundingClientRect()
@@ -159,6 +159,9 @@
      * @param {Event} e
      */
     function triggerLoadOrError(e) {
+        if (e.type === 'loadeddata') {
+            e.type = 'load';
+        }
         triggerEvent(e.type, $(this).off(load_error, triggerLoadOrError));
     }
 


### PR DESCRIPTION
`lazyload` event will now fire for HTML5 videos and `lazy-loaded` class will now be added to videos.

The solution was to also listen for the `loadeddata` event on video elements.