### PR TITLE
Create jquery.lazyloadxt.audio.js

### DIFF
--- a/src/jquery.lazyloadxt.audio.js
+++ b/src/jquery.lazyloadxt.audio.js
@@ -1,0 +1,29 @@
+(function($) {
+    'use strict';
+
+    var options = $.lazyLoadXT;
+
+    options.selector += ',audio';
+
+    $(document).on('lazyshow', 'audio', function(e, $el) {
+        var srcAttr = $el.lazyLoadXT.srcAttr,
+            isFuncSrcAttr = $.isFunction(srcAttr),
+            changed = false;
+
+        $el.children('source,track')
+            .each(function(index, el) {
+                var $child = $(el),
+                    src = isFuncSrcAttr ? srcAttr($child) : $child.attr(srcAttr);
+                if (src) {
+                    $child.attr('src', src);
+                    changed = true;
+                }
+            });
+
+        // reload video
+        if (changed) {
+            this.load();
+        }
+    });
+
+})(window.jQuery || window.Zepto || window.$);


### PR DESCRIPTION
I think support for the `<audio>` tag is missing in your plugin library. I am adding one. Please allow pull.

Thanks.