### PR TITLE
No need .removeAttr(bgAttr)

### DIFF
--- a/src/jquery.lazyloadxt.bg.js
+++ b/src/jquery.lazyloadxt.bg.js
@@ -15,7 +15,6 @@
         if (!!url) {
             $this
                 .css('background-image', "url('" + url + "')")
-                .removeAttr(bgAttr)
                 .triggerHandler('load');
         }
     });


### PR DESCRIPTION
No need .removeAttr(bgAttr) same as data-src for images by default.
This allows to add animation, for example
[data-bg] {
	opacity: 0;
	transition: opacity 0.5s ease;
}
.lazy-loaded[data-bg] {
	opacity: 1;
}