### PR TITLE
Avoid back button problem with Iframes in Firefox

### DIFF
--- a/src/jquery.lazyloadxt.js
+++ b/src/jquery.lazyloadxt.js
@@ -215,7 +215,10 @@
                         src = $isFunction(srcAttr) ? srcAttr($el) : el.getAttribute(srcAttr);
 
                     if (src) {
-                        el.src = src;
+                        if ( el.tagName === 'IFRAME' )
+                            el.contentWindow.location.replace( src );
+                        else
+                            el.src = src;
                     }
 
                     removeNode = true;


### PR DESCRIPTION
Avoid the back button problem with Iframes in Firefox, which causes the need to double click to return to the previous page when Lazyload-xt has already loaded the iframe.